### PR TITLE
ci: fix changelog generation by updating git-chglog repository

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate changelog
-        uses: anton-yurchenko/git-chglog@master
+        uses: git-chglog/git-chglog@master
         with:
           version: latest
           outfile: CHANGELOG.md


### PR DESCRIPTION
## Rationale
The CI workflow was failing because the repository `anton-yurchenko/git-chglog` is no longer available or accessible. This change updates the workflow to use the official `git-chglog/git-chglog` repository, which ensures the changelog is generated correctly during releases.

## Summary
Update the `git-chglog` GitHub Action to its official repository.

## Technical Implementation
Modified `.github/workflows/changelog.yml` to replace `anton-yurchenko/git-chglog@master` with `git-chglog/git-chglog@master`.

## Verification
The fix can be verified by triggering the `Changelog` workflow (e.g., by pushing a tag) or by checking that the repository reference is now correct in the workflow definition.